### PR TITLE
Exception handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@
 dist: xenial
 language: python
 python:
+  - 3.9
+  - 3.8
   - 3.7
   - 3.6
 
@@ -14,9 +16,8 @@ install:
 script: 
   - tox
   - python setup.py install
-  - python pysimpleapp/examples/thread_examples.py
-  - python pysimpleapp/examples/example_tm.py
-  - python pysimpleapp/examples/example_tm_multirun.py
+  - pip install -r requirements_dev.txt
+  - pytest
 
 # Assuming you have installed the travis-ci CLI tool, after you
 # create the Github repo and add it to Travis, run the

--- a/pysimpleapp/examples/threads.py
+++ b/pysimpleapp/examples/threads.py
@@ -23,6 +23,15 @@ class ExampleSingleRunThread(SingleRunThread):
         self.publish(None)
 
 
+class ExampleExceptionThread(SingleRunThread):
+    def setup(self):
+        pass
+
+    def main(self):
+        print("Running error thread...")
+        raise Exception
+
+
 class ExampleMultiRunThread(MultiRunThread):
     def setup(self):
         self.times_ran = 0

--- a/pysimpleapp/message.py
+++ b/pysimpleapp/message.py
@@ -2,9 +2,8 @@
 This module simply contains the message class which will be used to move information around the app
 """
 
-from dataclasses import dataclass
 from enum import Enum
-from typing import Tuple
+from typing import NamedTuple, Tuple
 from queue import Queue
 
 
@@ -16,7 +15,6 @@ class Commands(Enum):
     THREAD_HANDLE = "THREAD_HANDLE"
 
 
-@dataclass
 class Message:
     """
     Generic message class which will be used to move information around the system
@@ -28,9 +26,10 @@ class Message:
     :param package: Data transferred as part of the message
     """
 
-    sender: Tuple[str]
-    command: str
-    package: any
+    def __init__(self, sender: Tuple[str], command: str, package: any):
+        self.sender = sender
+        self.command = command
+        self.package = package
 
     def __str__(self):
         """Provides a human readable output of the message"""
@@ -39,7 +38,6 @@ class Message:
         )
 
 
-@dataclass
-class SubscriptionPackage:
+class SubscriptionPackage(NamedTuple):
     endpoint: str
     queue: Queue

--- a/tests/test_simple_thread_examples.py
+++ b/tests/test_simple_thread_examples.py
@@ -2,6 +2,7 @@ import threading
 import time
 from datetime import timedelta
 from queue import Queue
+from unittest.mock import Mock
 
 import pytest
 from tests.utils import min_sleep, send_subscription_message
@@ -10,6 +11,7 @@ from pysimpleapp.examples.threads import (
     ExampleMultiRunThread,
     ExampleAlternatingThread,
     ExampleRepeatingThread,
+    ExampleExceptionThread,
 )
 from pysimpleapp.message import Message, Commands
 
@@ -39,6 +41,20 @@ def test_single_run_thread_ends_straight_away():
     min_sleep()
 
     assert threading.active_count() == 2
+
+
+@pytest.mark.timeout(1, method="thread")
+def test_exception_can_be_caught(make_thread):
+    mock_supervisor = Mock()
+
+    e = make_thread(ExampleExceptionThread, "E", supervisor=mock_supervisor)
+
+    e.start()
+    min_sleep()
+
+    mock_supervisor.raise_exception.assert_called_once()
+    # Check that a reference to the thread is returned as the last argument
+    assert e is mock_supervisor.raise_exception.call_args.args[0][-1]
 
 
 @pytest.mark.timeout(1, method="thread")


### PR DESCRIPTION
Added exception handling to simple threads

Uses new `raise_exception` function to emulate `threading.excepthook` functionality without globally overriding it - while that would have worked it seemed like it would take too many options away from users. We are still raising the exceptions so anyone who wants to handle this in a custom manner can still override the `pysimpleapp` system.

Some additional housekeeping.